### PR TITLE
Update on write_mef_ts_data_and_indices function

### DIFF
--- a/pymef/mef_file/pymef3_file.c
+++ b/pymef/mef_file/pymef3_file.c
@@ -795,11 +795,7 @@ static PyObject *write_mef_ts_data_and_indices(PyObject *self, PyObject *args)
     tmd2->recording_duration = (si8) (((sf8)tmd2->number_of_samples / (sf8) tmd2->sampling_frequency) * 1e6);
     tmd2->number_of_blocks = (si8) ceil((sf8) tmd2->number_of_samples / (sf8) samps_per_mef_block);
     tmd2->maximum_block_samples = (ui4) samps_per_mef_block;
-
-    // Get the start time and end time from the metadata file
-    uh->start_time = metadata_fps->universal_header->start_time;
-    uh->end_time = metadata_fps->universal_header->end_time;
-    
+        
     // Set up mef3 time series indices file
     ts_indices_file_bytes = (tmd2->number_of_blocks * TIME_SERIES_INDEX_BYTES) + UNIVERSAL_HEADER_BYTES;
     ts_idx_fps = allocate_file_processing_struct(ts_indices_file_bytes, TIME_SERIES_INDICES_FILE_TYPE_CODE, NULL, metadata_fps, UNIVERSAL_HEADER_BYTES);

--- a/pymef/mef_file/pymef3_file.c
+++ b/pymef/mef_file/pymef3_file.c
@@ -804,10 +804,9 @@ static PyObject *write_mef_ts_data_and_indices(PyObject *self, PyObject *args)
     ts_indices_file_bytes = (tmd2->number_of_blocks * TIME_SERIES_INDEX_BYTES) + UNIVERSAL_HEADER_BYTES;
     ts_idx_fps = allocate_file_processing_struct(ts_indices_file_bytes, TIME_SERIES_INDICES_FILE_TYPE_CODE, NULL, metadata_fps, UNIVERSAL_HEADER_BYTES);
     MEF_snprintf(ts_idx_fps->full_file_name, MEF_FULL_FILE_NAME_BYTES, "%s/%s.%s", file_path, segment_name, TIME_SERIES_INDICES_FILE_TYPE_STRING);
-    uh = ts_idx_fps->universal_header;
-    generate_UUID(uh->file_UUID);
-    uh->number_of_entries = tmd2->number_of_blocks;
-    uh->maximum_entry_size = TIME_SERIES_INDEX_BYTES;
+    generate_UUID(ts_idx_fps->universal_header->file_UUID);
+    ts_idx_fps->universal_header->number_of_entries = tmd2->number_of_blocks;
+    ts_idx_fps->universal_header->maximum_entry_size = TIME_SERIES_INDEX_BYTES;
 
     // Set up mef3 time series data file
     ts_data_fps = allocate_file_processing_struct(UNIVERSAL_HEADER_BYTES + RED_MAX_COMPRESSED_BYTES(samps_per_mef_block, 1), TIME_SERIES_DATA_FILE_TYPE_CODE, NULL, metadata_fps, UNIVERSAL_HEADER_BYTES);

--- a/pymef/mef_file/pymef3_file.c
+++ b/pymef/mef_file/pymef3_file.c
@@ -754,30 +754,28 @@ static PyObject *write_mef_ts_data_and_indices(PyObject *self, PyObject *args)
     // Check for directory type
     MEF_strncpy(file_path, py_file_path, MEF_FULL_FILE_NAME_BYTES);
     extract_path_parts(file_path, path_out, name, type);
-    if (!strcmp(type,SEGMENT_DIRECTORY_TYPE_STRING)){
-        // Segment - OK - extract segment number and check for time series
-        uh->segment_number = extract_segment_number(&name[0]);
-
+    if (!strcmp(type,SEGMENT_DIRECTORY_TYPE_STRING)) {
+		
         // Copy the segment name for later use
         MEF_strncpy(segment_name, name, MEF_BASE_FILE_NAME_BYTES);
 
-        // TODO - extact segment number
+        // 
         MEF_strncpy(path_in, path_out, MEF_FULL_FILE_NAME_BYTES);
         extract_path_parts(path_in, path_out, name, type);
-        if (!strcmp(type,TIME_SERIES_CHANNEL_DIRECTORY_TYPE_STRING)){
-            MEF_strncpy(uh->channel_name, name, MEF_BASE_FILE_NAME_BYTES);
+        if (!strcmp(type,TIME_SERIES_CHANNEL_DIRECTORY_TYPE_STRING)) {
+            
             // Get session name
             MEF_strncpy(path_in, path_out, MEF_FULL_FILE_NAME_BYTES);
             extract_path_parts(path_in, path_out, name, type);
-            MEF_strncpy(uh->session_name, name, MEF_BASE_FILE_NAME_BYTES);
-        }else{
+            
+        } else {
             //Fire an error that this is not time series directory - hence makes no sense to write metadata
             PyErr_SetString(PyExc_RuntimeError, "Not a time series channel, exiting...");
             PyErr_Occurred();
             return NULL;
         }
 
-    }else{
+    } else {
         //Fire an error that this is not segment directory - hence makes no sense to write metadata
         PyErr_SetString(PyExc_RuntimeError, "Not a segment, exiting...");
         PyErr_Occurred();

--- a/pymef/mef_file/pymef3_file.c
+++ b/pymef/mef_file/pymef3_file.c
@@ -347,6 +347,7 @@ static PyObject *write_mef_data_records(PyObject *self, PyObject *args)
     write_MEF_file(rec_idx_fps);
     free_file_processing_struct(rec_data_fps);
     free_file_processing_struct(rec_idx_fps);
+    free_file_processing_struct(gen_fps);
     Py_INCREF(Py_None);
     return Py_None;
 }
@@ -491,7 +492,8 @@ static PyObject *write_mef_ts_metadata(PyObject *self, PyObject *args)
     MEF_globals->recording_time_offset = metadata_fps->metadata.section_3->recording_time_offset;
 
     write_MEF_file(metadata_fps);
-    free_file_processing_struct(metadata_fps); 
+    free_file_processing_struct(metadata_fps);
+    free_file_processing_struct(gen_fps);
 
     Py_INCREF(Py_None);
     return Py_None;
@@ -639,6 +641,7 @@ static PyObject *write_mef_v_metadata(PyObject *self, PyObject *args)
     write_MEF_file(metadata_fps);
 
     free_file_processing_struct(metadata_fps);
+    free_file_processing_struct(gen_fps);
 
     Py_INCREF(Py_None);
     return Py_None;
@@ -1064,6 +1067,7 @@ static PyObject *write_mef_v_indices(PyObject *self, PyObject *args)
 
     // clean up
     free_file_processing_struct(v_idx_fps);
+    free_file_processing_struct(gen_fps);
 
     Py_INCREF(Py_None);
     return Py_None;

--- a/pymef/mef_file/pymef3_file.c
+++ b/pymef/mef_file/pymef3_file.c
@@ -484,7 +484,7 @@ static PyObject *write_mef_ts_metadata(PyObject *self, PyObject *args)
     // Get time series metadata section 2 from python dict
     map_python_tmd2(py_tmd2_dict, metadata_fps->metadata.time_series_section_2);
 
-    // Get time series metadata section 2 from python dict
+    // Get metadata section 3 from python dict
     map_python_md3(py_md3_dict, metadata_fps->metadata.section_3);
 
     // Assign recording_time_offset
@@ -584,7 +584,7 @@ static PyObject *write_mef_v_metadata(PyObject *self, PyObject *args)
     extract_path_parts(py_file_path, path_out, name, type);
     MEF_strncpy(file_path, py_file_path, MEF_FULL_FILE_NAME_BYTES);
     if (!strcmp(type,SEGMENT_DIRECTORY_TYPE_STRING)){
-        // Segment - OK - extract segment number and check for time series
+        // Segment - OK - extract segment number and check for video
         uh->segment_number = extract_segment_number(&name[0]);
 
         // Copy the segment name for later use
@@ -600,7 +600,7 @@ static PyObject *write_mef_v_metadata(PyObject *self, PyObject *args)
             extract_path_parts(path_in, path_out, name, type);
             MEF_strncpy(uh->session_name, name, MEF_BASE_FILE_NAME_BYTES);
         }else{
-            //Fire an error that this is not time series directory - hence makes no sense to write metadata
+            //Fire an error that this is not video directory - hence makes no sense to write metadata
             PyErr_SetString(PyExc_RuntimeError, "Not a video channel, exiting...");
             PyErr_Occurred();
             return NULL;
@@ -616,7 +616,7 @@ static PyObject *write_mef_v_metadata(PyObject *self, PyObject *args)
     // generate level UUID into generic universal_header
     generate_UUID(gen_fps->universal_header->level_UUID);
 
-    // set up mef3 time series metadata file
+    // set up mef3 video metadata file
     metadata_fps = allocate_file_processing_struct(METADATA_FILE_BYTES, VIDEO_METADATA_FILE_TYPE_CODE, NULL, gen_fps, UNIVERSAL_HEADER_BYTES);
     MEF_snprintf(metadata_fps->full_file_name, MEF_FULL_FILE_NAME_BYTES, "%s/%s.%s", py_file_path, segment_name, VIDEO_METADATA_FILE_TYPE_STRING);
     uh = metadata_fps->universal_header;
@@ -627,10 +627,10 @@ static PyObject *write_mef_v_metadata(PyObject *self, PyObject *args)
     metadata_fps->metadata.section_1->section_2_encryption = LEVEL_1_ENCRYPTION_DECRYPTED;
     metadata_fps->metadata.section_1->section_3_encryption = LEVEL_2_ENCRYPTION_DECRYPTED;
 
-    // Get time series metadata section 2 from python dict
+    // Get video metadata section 2 from python dict
     map_python_vmd2(py_vmd2_dict, metadata_fps->metadata.video_section_2);
 
-    // Get time series metadata section 2 from python dict
+    // Get metadata section 3 from python dict
     map_python_md3(py_md3_dict, metadata_fps->metadata.section_3);
 
     // Apply recording offset

--- a/pymef/mef_file/pymef3_file.c
+++ b/pymef/mef_file/pymef3_file.c
@@ -745,10 +745,9 @@ static PyObject *write_mef_ts_data_and_indices(PyObject *self, PyObject *args)
     // set up a generic mef3 fps for universal header and password data
     gen_fps = allocate_file_processing_struct(UNIVERSAL_HEADER_BYTES, NO_FILE_TYPE_CODE, NULL, NULL, 0);
     initialize_universal_header(gen_fps, MEF_TRUE, MEF_FALSE, MEF_TRUE);
-    uh = gen_fps->universal_header;
     
     MEF_globals->behavior_on_fail = SUPPRESS_ERROR_OUTPUT;
-    pwd = process_password_data(NULL, level_1_password, level_2_password, uh);
+    pwd = process_password_data(NULL, level_1_password, level_2_password, gen_fps->universal_header);
     MEF_globals->behavior_on_fail = EXIT_ON_FAIL;
 
     // Check for directory type

--- a/pymef/mef_file/pymef3_file.c
+++ b/pymef/mef_file/pymef3_file.c
@@ -752,7 +752,7 @@ static PyObject *write_mef_ts_data_and_indices(PyObject *self, PyObject *args)
     MEF_strncpy(file_path, py_file_path, MEF_FULL_FILE_NAME_BYTES);
     extract_path_parts(file_path, path_out, name, type);
     if (!strcmp(type,SEGMENT_DIRECTORY_TYPE_STRING)){
-    // segment type/directory
+        // segment type/directory
 
         // copy the segment name for file name construction later
         MEF_strncpy(segment_name, name, MEF_BASE_FILE_NAME_BYTES);

--- a/pymef/mef_file/pymef3_file.c
+++ b/pymef/mef_file/pymef3_file.c
@@ -748,7 +748,7 @@ static PyObject *write_mef_ts_data_and_indices(PyObject *self, PyObject *args)
     uh = gen_fps->universal_header;
     
     MEF_globals->behavior_on_fail = SUPPRESS_ERROR_OUTPUT;
-    pwd = gen_fps->password_data = process_password_data(NULL, level_1_password, level_2_password, uh);
+    pwd = process_password_data(NULL, level_1_password, level_2_password, uh);
     MEF_globals->behavior_on_fail = EXIT_ON_FAIL;
 
     // Check for directory type

--- a/pymef/mef_file/pymef3_file.c
+++ b/pymef/mef_file/pymef3_file.c
@@ -661,7 +661,7 @@ static PyObject *write_mef_ts_data_and_indices(PyObject *self, PyObject *args)
 
     // Method specific
     PASSWORD_DATA           *pwd;
-    UNIVERSAL_HEADER    *uh;
+    UNIVERSAL_HEADER    *ts_data_uh;
     FILE_PROCESSING_STRUCT  *gen_fps, *metadata_fps, *ts_idx_fps, *ts_data_fps;
     TIME_SERIES_METADATA_SECTION_2  *tmd2;
     TIME_SERIES_INDEX   *tsi;
@@ -804,10 +804,10 @@ static PyObject *write_mef_ts_data_and_indices(PyObject *self, PyObject *args)
     // Set up mef3 time series data file
     ts_data_fps = allocate_file_processing_struct(UNIVERSAL_HEADER_BYTES + RED_MAX_COMPRESSED_BYTES(samps_per_mef_block, 1), TIME_SERIES_DATA_FILE_TYPE_CODE, NULL, metadata_fps, UNIVERSAL_HEADER_BYTES);
     MEF_snprintf(ts_data_fps->full_file_name, MEF_FULL_FILE_NAME_BYTES, "%s/%s.%s", file_path, segment_name, TIME_SERIES_DATA_FILE_TYPE_STRING);
-    uh = ts_data_fps->universal_header;
-    generate_UUID(uh->file_UUID);
-    uh->number_of_entries = tmd2->number_of_blocks;
-    uh->maximum_entry_size = samps_per_mef_block;
+    ts_data_uh = ts_data_fps->universal_header;
+    generate_UUID(ts_data_uh->file_UUID);
+    ts_data_uh->number_of_entries = tmd2->number_of_blocks;
+    ts_data_uh->maximum_entry_size = samps_per_mef_block;
     ts_data_fps->directives.io_bytes = UNIVERSAL_HEADER_BYTES;
     ts_data_fps->directives.close_file = MEF_FALSE;
     write_MEF_file(ts_data_fps);
@@ -899,7 +899,7 @@ static PyObject *write_mef_ts_data_and_indices(PyObject *self, PyObject *args)
     // Write the files
     ts_data_fps->universal_header->header_CRC = CRC_calculate(ts_data_fps->raw_data + CRC_BYTES, UNIVERSAL_HEADER_BYTES - CRC_BYTES);
     e_fseek(ts_data_fps->fp, 0, SEEK_SET, ts_data_fps->full_file_name, __FUNCTION__, __LINE__, MEF_globals->behavior_on_fail);
-    e_fwrite(uh, sizeof(ui1), UNIVERSAL_HEADER_BYTES, ts_data_fps->fp, ts_data_fps->full_file_name, __FUNCTION__, __LINE__, MEF_globals->behavior_on_fail);
+    e_fwrite(ts_data_uh, sizeof(ui1), UNIVERSAL_HEADER_BYTES, ts_data_fps->fp, ts_data_fps->full_file_name, __FUNCTION__, __LINE__, MEF_globals->behavior_on_fail);
     fclose(ts_data_fps->fp);
     // write out metadata & time series indices files
     write_MEF_file(metadata_fps);

--- a/pymef/mef_session.py
+++ b/pymef/mef_session.py
@@ -543,7 +543,7 @@ class MefSession():
                                   samps_per_mef_block,
                                   data):
         """
-        Writes new time series metadata in the specified segment
+        Writes new time series data in the specified segment
 
         Parameters
         ----------


### PR DESCRIPTION
Hey Dan,

I was working with the `write_mef_ts_data_and_indices` function and saw that there were improvements possible (which are in my code as well). Mainly, the `uh` pointer variable is used to point to the universal-headers of multiple files (generic fps, data-file fps and index-file fps), making the code difficult to follow and prone to errors. I simplified and corrected some empty operations:

- Simplified the changes to the time-series index fps. Skipped assignment:
`uh = ts_idx_fps->universal_header;`
That reassignment get's overwritten 6 lines later (to `ts_data_fps`) and we can do direct referencing. Which results in less "reassignments" of the `uh` pointer variable.
- Assigning values to the start_time and end_time of the universal header of the generic fps (`uh` pointer variable at the beginning of the function):
```
    uh->start_time = metadata_fps->universal_header->start_time;
    uh->end_time = metadata_fps->universal_header->end_time;
```
does not make sense since nothing relevant happens to the generic `fps` and `uh` after. The `uh` pointer variable is "repointed" to `ts_data_fps->universal_header` shortly after and `gen_fps` is never used again. The `start_time` and `end_time` values are actually transferred from the metadata file at the line: 
```
FILE_PROCESSING_STRUCT *ts_data_fps = allocate_file_processing_struct(UNIVERSAL_HEADER_BYTES + RED_MAX_COMPRESSED_BYTES(samples_per_block, 1), TIME_SERIES_DATA_FILE_TYPE_CODE, NULL, metadata_fps, UNIVERSAL_HEADER_BYTES);
```

- I think part of the code that makes use of the universal header of the generic fps (`gen_fps`) is copied over from the `write_mef_ts_metadata` function, in which `gen_fps` and it's universal header are actually used. As a result of this copying some code does not do anything or can be simplified:
    - The extractions of the segment number (`uh->segment_number = extract_segment_number(&name[0]);`), channel name (`MEF_strncpy(uh->channel_name, name, MEF_BASE_FILE_NAME_BYTES);`) and session name (`MEF_strncpy(uh->session_name, name, MEF_BASE_FILE_NAME_BYTES);`) are stored in the universal header of the generic mef fps (`gen_fps`) but are never used anywhere. Which makes sense because these fields are copied later from metadata file fps/universal header. These extractions can just be removed.
    - As you probably already felt and described in a comment in the code (you wrote: `// NOTE: gen_fps is unecessart here if the metadata file with the universal header already exists, or is it?`). The generic MEF fps/uh ('gen_fps') is not very relevant for the function, except to provide a universal header:
`uh = gen_fps->universal_header;`
to generate a password on:
`pwd = process_password_data(NULL, level_1_password, level_2_password, uh);`
Indeed all is based on the metadata file universal header and this is just copied over from the 'write_mef_ts_metadata' function. Therefore we can simplify the password part to not use 'uh' as an extra step and just write:
`pwd = process_password_data(NULL, password_l1, password_l2, gen_fps->universal_header);`
- Now after all of the above steps, the 'uh' variable is only used for the time-series fps, at:
`uh = ts_data_fps->universal_header;`
Since it will only refer to that, I renamed that variable to `ts_data_uh` to make the code more readable

- Last, I updated the comments in the function to describe a more of what is going on


I tested the code so it should be good.

Best,
Max