### PR TITLE
Fixed 'depracated ndim > 0 to scalar' warnings for tests

### DIFF
--- a/pymef/mef_session.py
+++ b/pymef/mef_session.py
@@ -1388,8 +1388,7 @@ class MefSession():
                                     uutc_ss[0], uutc_ss[1], True)
             if out_nans and data is None:
                 channel_md = self.session_md['time_series_channels'][channel]
-                size = ((np.diff(uutc_ss)/1e6)
-                        * channel_md['section_2']['sampling_frequency'])
+                size = ((np.diff(uutc_ss) / 1e6)[0] * channel_md['section_2']['sampling_frequency'][0])
                 data = np.empty(int(size))
                 data[:] = np.nan
             data_list.append(data)

--- a/tests/pymef_test.py
+++ b/tests/pymef_test.py
@@ -629,8 +629,8 @@ class TestStringMethods(unittest.TestCase):
 
         ch_md2 = ch_md['section_2']
 
-        start = int(ch_md2['start_sample'] - self.samps_per_mef_block)
-        end = int(ch_md2['start_sample'] + self.samps_per_mef_block)
+        start = int(ch_md2['start_sample'][0] - self.samps_per_mef_block)
+        end = int(ch_md2['start_sample'][0] + self.samps_per_mef_block)
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
@@ -649,8 +649,8 @@ class TestStringMethods(unittest.TestCase):
 
         ch_md2 = ch_md['section_2']
 
-        start = int(ch_md2['number_of_samples'] - self.samps_per_mef_block)
-        end = int(ch_md2['number_of_samples'] + self.samps_per_mef_block)
+        start = int(ch_md2['number_of_samples'][0] - self.samps_per_mef_block)
+        end = int(ch_md2['number_of_samples'][0] + self.samps_per_mef_block)
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
@@ -670,8 +670,8 @@ class TestStringMethods(unittest.TestCase):
 
         ch_md2 = ch_md['section_2']
 
-        start = int(ch_md2['start_sample'] - (self.samps_per_mef_block * 2))
-        end = int(ch_md2['start_sample'] - self.samps_per_mef_block)
+        start = int(ch_md2['start_sample'][0] - (self.samps_per_mef_block * 2))
+        end = int(ch_md2['start_sample'][0] - self.samps_per_mef_block)
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
@@ -690,8 +690,8 @@ class TestStringMethods(unittest.TestCase):
 
         ch_md2 = ch_md['section_2']
 
-        start = int(ch_md2['number_of_samples'] + self.samps_per_mef_block)
-        end = int(ch_md2['number_of_samples'] + (self.samps_per_mef_block * 2))
+        start = int(ch_md2['number_of_samples'][0] + self.samps_per_mef_block)
+        end = int(ch_md2['number_of_samples'][0] + (self.samps_per_mef_block * 2))
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
@@ -724,8 +724,8 @@ class TestStringMethods(unittest.TestCase):
 
         ch_md_spec = ch_md['channel_specific_metadata']
 
-        start = int(ch_md_spec['earliest_start_time'] - 1e6)
-        end = int(ch_md_spec['earliest_start_time'] + 1e6)
+        start = int(ch_md_spec['earliest_start_time'][0] - 1e6)
+        end = int(ch_md_spec['earliest_start_time'][0] + 1e6)
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
@@ -744,8 +744,8 @@ class TestStringMethods(unittest.TestCase):
 
         ch_md_spec = ch_md['channel_specific_metadata']
 
-        start = int(ch_md_spec['latest_end_time'] - 1e6)
-        end = int(ch_md_spec['latest_end_time'] + 1e6)
+        start = int(ch_md_spec['latest_end_time'][0] - 1e6)
+        end = int(ch_md_spec['latest_end_time'][0] + 1e6)
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
@@ -764,8 +764,8 @@ class TestStringMethods(unittest.TestCase):
 
         ch_md_spec = ch_md['channel_specific_metadata']
 
-        start = int(ch_md_spec['earliest_start_time'] - (1e6 * 2))
-        end = int(ch_md_spec['earliest_start_time'] - 1e6)
+        start = int(ch_md_spec['earliest_start_time'][0] - (1e6 * 2))
+        end = int(ch_md_spec['earliest_start_time'][0] - 1e6)
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
@@ -783,8 +783,8 @@ class TestStringMethods(unittest.TestCase):
 
         ch_md_spec = ch_md['channel_specific_metadata']
 
-        start = int(ch_md_spec['latest_end_time'] + 1e6)
-        end = int(ch_md_spec['latest_end_time'] + (1e6 * 2))
+        start = int(ch_md_spec['latest_end_time'][0] + 1e6)
+        end = int(ch_md_spec['latest_end_time'][0] + (1e6 * 2))
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")


### PR DESCRIPTION
Hey Jan,

In response to your messages on my previous PR (https://github.com/msel-source/pymef/pull/31): Yeah, I've noticed the failed tests as well. Sorry I didn't check into them before.

They are caused by the asserts that check the number of warnings:
`self.assertEqual(len(w), 1)`

which should have only one warning (as the test expects), but instead end up with two.
The second warning for all of these is actually:
`DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
`

This warning is the root of the problem and is thrown by the most recent version of NumPy in the tests. These are thrown because the `PyArray_NewFromDescr` in most of the `create_*` functions (in pymef3_file.c) create an ndarray with one element in a single dimension. Before Numpy 1.25, you could simply refer to the whole ndarray and if there was only one value then it would convert that to a scalar. However, as of Numpy 1.25 we will have to be explicit about picking the scalar from the ndarray, which in our case is simply to add `[0]`.

Fixing these `ndim > 0 to a scalar` warnings in both `pymef_test.py` and `mef_session.py` allowed the tests to complete succesfully again, as you can hopefully see in this PR :)

Best,
Max

