### PR TITLE
Implementation of map_indices_flag & argument to copy metadata to dictionaries

### DIFF
--- a/pymef/mef_file/pymef3_file.c
+++ b/pymef/mef_file/pymef3_file.c
@@ -2505,7 +2505,7 @@ void    map_python_Epoc_type(PyObject *Epoc_type_arr, MEFREC_Epoc_1_0  *r_type) 
 
 // map a char array with a maximum number of byets) to a Python string
 PyObject *map_mef3_decode_maxbytes_to_string(const char *s, size_t max_size) {
-	size_t str_len = strnlen_s(s, max_size);
+	size_t str_len = strnlen(s, max_size);
 	return map_mef3_decode_sizebytes_to_string(s, str_len);
 }
 


### PR DESCRIPTION
Hi!

This PR has two enhancements for the `read_mef_session_metadata`, `read_mef_channel_metadata` and `read_mef_segment_metadata` functions:

1. Finishes the implementation of the `map_indices_flag`. This optional argument was already present but did not do anything, now it does.

2. It adds an additional optional argument (`copy_metadata_to_dict`) to copy the metadata solely into standard python dictionaries and return that to the user; instead of returning a dictionary that often branches into numpy structured array objects that have pointers to underlying C data.

- With the `copy_metadata_to_dict` option set to true, the data is copied into python objects that own their own data while the complete session/channel/segment is cleared in c. This has the advantage that no separate call to C is required to empty the struct that underlies the returned object. The returned python object can just be deleted(or None'ed) which frees all the data.

- To ensure backward compatibility, the `copy_metadata_to_dict` options is False by default, mapping to numpy structured array objects using exactly the same routines that were always there.

- The dictionaries have the exact same keys as the numpy structured arrays. So for example:
session_md['session_specific_metadata']['number_of_video_channels']
will work for both ndarrays (copy_metadata_to_dict=False) as with dictionaries (copy_metadata_to_dict=True)

- An addition advantage of copy_metadata_to_dict is that it makes inspection of the structure slightly easier:
ndarray:
![image](https://github.com/msel-source/pymef/assets/43676624/e81f7797-9298-4f38-8d6b-6e70c6110d95)
dict:
![image](https://github.com/msel-source/pymef/assets/43676624/f35a7244-4b13-4b8c-b894-0802fc67854b)

Hope these enhancements are acceptable
@cimbi I'll do one last PR after this one to see if I can fix Tom his issue, thanks!!

Best,
Max




