### PR TITLE
Fix C-API incompatibility

### DIFF
--- a/pymef/mef_file/pymef3_file.c
+++ b/pymef/mef_file/pymef3_file.c
@@ -65,7 +65,7 @@
     Py_DECREF(py_value_obj);	py_value_obj = NULL;
 
 #define PY_DICTSET_BYTEARRSIZE(dict, name, value, length) \
-	py_value_obj = PyByteArray_FromStringAndSize(value, length); \
+	py_value_obj = PyByteArray_FromStringAndSize((const char*)value, length); \
     PyDict_SetItemString(dict, name, py_value_obj); \
     Py_DECREF(py_value_obj);	py_value_obj = NULL;
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,6 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "numpy"
+    "oldest-supported-numpy"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
@cimbi Sorry to be back with a PR so quickly already :)

Both @dorahermes and me encountered this problem while using PyMef:
`RuntimeError: module compiled against API version 0x10 but this version of numpy is 0xf . Check the section C-API incompatibility at the Troubleshooting ImportError section at https://numpy.org/devdocs/user/troubleshooting-importerror.html#c-api-incompatibility for indications on how to solve this problem .
`

It mostly occurs on Python versions before 3.11 (e.g. 3.8) and is likely due to, as Numpy describes it: 
`A bad extension “wheel” (binary install) that should use [oldest-support-numpy]`
https://numpy.org/devdocs/user/troubleshooting-importerror.html#c-api-incompatibility

Luckely, Numpy themselves offer a very easy fix for this problem, which is using `oldest-supported-numpy`.
That way - as I understand it - each wheel (python version) should resort to a compatible Numpy version during the build.

I've applied their fix here in this PR. However, this does require a recompile and bump to version 1.4.1 to test if it works.
Hope you would consider this..

Best,
Max