### PR TITLE
Fix to include essential header (and extra source) files in distribution package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+recursive-include pymef *.py
+include pymef/mef_file/*.h
+include pymef/mef_file/*.c
+include meflib/meflib/*.h
+include meflib/meflib/*.c

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,10 @@ classifiers = [
 keywords = ["MEF", "Mayo", "Electrophysiology"]
 dynamic = ["version"]
 
+[tool.setuptools]
+include-package-data = true
+packages = ['pymef', 'pymef.mef_file']
+
 [tool.setuptools.dynamic]
 version = {attr = "pymef.version.__version__"}
 


### PR DESCRIPTION
Hi @cimbi 

I was testing a `python -m build` on Pymef to create a distribution package, and while doing so I discoved how to fix the inclusion of the header files (the problem in: https://github.com/msel-source/pymef/issues/30).

The solution is simply a matter of adding a MANIFEST.in file to indicate which extra - but in our case essential - files should be included in a distribution. Both `meflib` (.c/.h files) and `pymef3_file.h` were not included in 1.3.6, so it cannot be build.
With this PR they are included and it builds perfectly fine.

Best,
Max

