### PR TITLE
Build and upload sdist on tagged releases

### DIFF
--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -76,12 +76,17 @@ jobs:
         pip install setuptools
         pip install numpy
         pip install twine
+        pip install build
 
     - name: Build wheels
       run: python -m cibuildwheel --output-dir dist/
       env:
         CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
         CIBW_ARCHS_MACOS: universal2
+
+    - name: Build sdist
+      if: matrix.buildplat[1] == 'manylinux_x86_64' && matrix.python == 'cp312'
+      run: python -m build --sdist
 
     - name: Publish package
       env:


### PR DESCRIPTION
## Summary
- Adds sdist build step to the release CI job so source distributions are automatically published to PyPI alongside wheels
- Ensures users on platforms without pre-built wheels can install from source via `pip install pymef`

## Context
The build failure on macOS ARM64 with Python 3.12+ (incompatible function pointer types) was already fixed in v1.4.5. However, the CI only built platform-specific wheels — no sdist was uploaded. This meant `pip install pymef` could fall back to an older sdist (v1.4.2) lacking the fix.

This change prevents that from happening again on future releases.

Fixes #42